### PR TITLE
fix observed warnings with python 3.6.5 on windows

### DIFF
--- a/chumpy/__init__.py
+++ b/chumpy/__init__.py
@@ -1,10 +1,13 @@
-from .ch import *
-from .logic import *
+# For relative imports to work in Python 3.6
+import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
-from .optimization import minimize
+from ch import *
+from logic import *
+
+from optimization import minimize
 import extras
 import testing
-from .version import version as __version__
+from version import version as __version__
 
 from numpy import bool, int, float, complex, object, unicode, str, nan, inf
 

--- a/chumpy/__init__.py
+++ b/chumpy/__init__.py
@@ -6,8 +6,6 @@ import extras
 import testing
 from version import version as __version__
 
-from version import version as __version__
-
 from numpy import bool, int, float, complex, object, unicode, str, nan, inf
 
 def test():
@@ -107,12 +105,12 @@ print y # should be all 0.5
 
 def demo(which=None):
     if which not in demos:
-        print 'Please indicate which demo you want, as follows:'
+        print('Please indicate which demo you want, as follows:')
         for key in demos:
-            print "\tdemo('%s')" % (key,)
+            print("\tdemo('%s')" % (key,))
         return
 
-    print '- - - - - - - - - - - <CODE> - - - - - - - - - - - -'
-    print demos[which]
-    print '- - - - - - - - - - - </CODE> - - - - - - - - - - - -\n'
+    print('- - - - - - - - - - - <CODE> - - - - - - - - - - - -')
+    print(demos[which])
+    print('- - - - - - - - - - - </CODE> - - - - - - - - - - - -\n')
     exec('global np\n' + demos[which], globals(), locals())

--- a/chumpy/__init__.py
+++ b/chumpy/__init__.py
@@ -1,10 +1,10 @@
-from ch import *
-from logic import *
+from .ch import *
+from .logic import *
 
-from optimization import minimize
+from .optimization import minimize
 import extras
 import testing
-from version import version as __version__
+from .version import version as __version__
 
 from numpy import bool, int, float, complex, object, unicode, str, nan, inf
 

--- a/chumpy/ch.py
+++ b/chumpy/ch.py
@@ -1339,16 +1339,16 @@ def main():
     x30 = Ch(30)
     
     tmp = ChLambda(lambda x, y, z: Ch(1) + Ch(2) * Ch(3) + 4)
-    print tmp.dr_wrt(tmp.x)
+    print(tmp.dr_wrt(tmp.x))
     import pdb; pdb.set_trace()
     #a(b(c(d(e(f),g),h)))
     
     blah = tst(x10, x20, x30)
     
-    print blah.r
+    print(blah.r)
 
 
-    print foo
+    print(foo)
     
     import pdb; pdb.set_trace()
     

--- a/chumpy/ch.py
+++ b/chumpy/ch.py
@@ -662,7 +662,7 @@ class Ch(object):
 
             if hasattr(p, 'dterms') and p is not wrt and p.is_dr_wrt(wrt):
                 if not isinstance(p, Ch):
-                    print 'BROKEN!'
+                    print('BROKEN!')
                     raise Exception('Broken Should be Ch object')
 
                 indirect_dr = p.lmult_wrt(self._superdot(lhs, self._compute_dr_wrt_sliced(p)), wrt)

--- a/chumpy/ch_ops.py
+++ b/chumpy/ch_ops.py
@@ -47,7 +47,7 @@ __all__ += numpy_array_creation_routines
 import ch
 import numpy as np
 import warnings
-import cPickle as pickle
+import pickle # import cPickle as pickle
 import scipy.sparse as sp
 from utils import row, col
 from copy import copy as copy_copy

--- a/chumpy/linalg.py
+++ b/chumpy/linalg.py
@@ -284,17 +284,17 @@ def slogdet(*args):
 def main():
     
     tmp = ch.random.randn(100).reshape((10,10))
-    print 'chumpy version: ' + str(slogdet(tmp)[1].r)
-    print 'old version:' + str(np.linalg.slogdet(tmp.r)[1])
+    print('chumpy version: ' + str(slogdet(tmp)[1].r))
+    print('old version:' + str(np.linalg.slogdet(tmp.r)[1]))
 
     eps = 1e-10
     diff = np.random.rand(100) * eps
     diff_reshaped = diff.reshape((10,10))
-    print np.linalg.slogdet(tmp.r+diff_reshaped)[1] - np.linalg.slogdet(tmp.r)[1]
-    print slogdet(tmp)[1].dr_wrt(tmp).dot(diff)
+    print(np.linalg.slogdet(tmp.r+diff_reshaped)[1] - np.linalg.slogdet(tmp.r)[1])
+    print(slogdet(tmp)[1].dr_wrt(tmp).dot(diff))
     
-    print np.linalg.slogdet(tmp.r)[0]
-    print slogdet(tmp)[0]
+    print(np.linalg.slogdet(tmp.r)[0])
+    print(slogdet(tmp)[0])
 
 if __name__ == '__main__':
     main()

--- a/chumpy/logic.py
+++ b/chumpy/logic.py
@@ -35,5 +35,5 @@ __all__ += unaries
 
 if __name__ == '__main__':
     import ch
-    print all(np.array([1,2,3]))
-    print isinf(np.array([0,2,3]))
+    print(all(np.array([1,2,3])))
+    print(isinf(np.array([0,2,3])))


### PR DESCRIPTION
FIXME: have not checked for backwards compatibility with python 2.7